### PR TITLE
Get current version directly from package.json

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,9 +3,10 @@
 var program = require('commander');
 var Watson = require('./watson');
 var watson = new Watson();
+var version = require('../package.json').version;
 
 program
-  .version('0.5.0');
+  .version(version);
 
 program
   .command('upgrade-qunit-tests [testsPath]')


### PR DESCRIPTION
In this way ember-watson command is always up to date with the installed package version