### PR TITLE
Bugfix: it should traverse nested routes not just resource routes

### DIFF
--- a/lib/formulas/resource-router-mapping.js
+++ b/lib/formulas/resource-router-mapping.js
@@ -26,12 +26,12 @@ module.exports = function transformResourceRouterMapping(source) {
 
 function traverseExpressions(routes) {
   routes.forEach(function (route) {
-    if (isRoute(route)) {
+    if (isResourceRoute(route)) {
       transformResourceToRoute(route);
-      var lastArgument = route.expression.arguments[route.expression.arguments.length-1];
-      if (types.FunctionExpression.check(lastArgument)) {
-        traverseExpressions(lastArgument.body.body);
-      }
+    }
+    var lastArgument = route.expression.arguments[route.expression.arguments.length-1];
+    if (types.FunctionExpression.check(lastArgument)) {
+      traverseExpressions(lastArgument.body.body);
     }
   });
 }
@@ -64,7 +64,7 @@ function transformResourceToRoute(route) {
   optionsObject.properties.push(resetNamespaceOption);
 }
 
-function isRoute(route) {
+function isResourceRoute(route) {
   return types.ExpressionStatement.check(route) &&
     types.CallExpression.check(route.expression) &&
     types.MemberExpression.check(route.expression.callee) &&

--- a/tests/fixtures/resource-router-mapping/new-complex-ember-cli-sample.js
+++ b/tests/fixtures/resource-router-mapping/new-complex-ember-cli-sample.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+var Router = Ember.Router.extend({
+  location: config.locationType
+});
+
+Router.map(function() {
+  this.route('login');
+  this.route('doorkeeper');
+
+  this.route('protected', {path: '/'}, function(){
+    this.route('dashboard', {
+      resetNamespace: true
+    }, Ember.K);
+    this.route('entry', {
+      path: 'entries/:entry_id',
+      resetNamespace: true
+    });
+    this.route('employees', {
+      resetNamespace: true
+    }, function() {
+      this.route('employee', {
+        path: ':employee_id',
+        resetNamespace: true
+      });
+      this.route('new-employee', {
+        path: 'new',
+        resetNamespace: true
+      });
+    });
+    this.route('import', {
+      path: 'employees/import',
+      resetNamespace: true
+    });
+    this.route('sync-settings', {
+      path: 'employees/sync-settings',
+      resetNamespace: true
+    });
+    this.route('devices', {
+      resetNamespace: true
+    }, function(){
+      this.route('ipads', {
+        resetNamespace: true
+      });
+      this.route('printers', {
+        resetNamespace: true
+      });
+    });
+  });
+});
+
+export default Router;

--- a/tests/fixtures/resource-router-mapping/old-complex-ember-cli-sample.js
+++ b/tests/fixtures/resource-router-mapping/old-complex-ember-cli-sample.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+var Router = Ember.Router.extend({
+  location: config.locationType
+});
+
+Router.map(function() {
+  this.route('login');
+  this.route('doorkeeper');
+
+  this.route('protected', {path: '/'}, function(){
+    this.resource('dashboard', Ember.K);
+    this.resource('entry', { path: 'entries/:entry_id' });
+    this.resource('employees', function() {
+      this.resource('employee', { path: ':employee_id' });
+      this.resource('new-employee', { path: 'new' });
+    });
+    this.resource('import', { path: 'employees/import' });
+    this.route('sync-settings', {
+      path: 'employees/sync-settings',
+      resetNamespace: true
+    });
+    this.resource('devices', function(){
+      this.resource('ipads');
+      this.resource('printers');
+    });
+  });
+});
+
+export default Router;

--- a/tests/resource-route-mapping-test.js
+++ b/tests/resource-route-mapping-test.js
@@ -36,5 +36,13 @@ describe('Resource router mapping', function() {
 
       astEquality(newSource, expectedNewSource);
     });
+
+    it('transform complex ember-cli file format', function() {
+      var source            = fs.readFileSync(baseDir + '/old-complex-ember-cli-sample.js');
+      var newSource         = watson._transformResourceRouterMapping(source);
+      var expectedNewSource = fs.readFileSync(baseDir + '/new-complex-ember-cli-sample.js');
+
+      astEquality(newSource, expectedNewSource);
+    });
   });
 });


### PR DESCRIPTION
At the moment just children from `resource`s are being processed. This PR changes this behaviour to process `route`s as well. Because

```js
this.route('foo', function() {
  this.resource('bar');
})
```

is a valid mapping.

//cc @abuiles 