### PR TITLE
Update QUnit transformation to work with QUnit.test style.

### DIFF
--- a/lib/formulas/qunit-transforms.js
+++ b/lib/formulas/qunit-transforms.js
@@ -21,17 +21,38 @@ var ASSERTIONS = [
 
 function isModule(node) {
   return types.CallExpression.check(node.expression) &&
-    node.expression.callee.name === 'module';
+    (
+      node.expression.callee.name === 'module' ||
+      (
+        node.expression.callee.type === 'MemberExpression' &&
+        node.expression.callee.object.name === 'QUnit' &&
+        node.expression.callee.property.name === 'module'
+      )
+    );
 }
 
 function isTest(node) {
   return types.CallExpression.check(node.expression) &&
-    node.expression.callee.name === 'test';
+    (
+      node.expression.callee.name === 'test' ||
+      (
+        node.expression.callee.type === 'MemberExpression' &&
+        node.expression.callee.object.name === 'QUnit' &&
+        node.expression.callee.property.name === 'test'
+      )
+    );
 }
 
 function isSkip(node) {
   return types.CallExpression.check(node.expression) &&
-    node.expression.callee.name === 'skip';
+    (
+      node.expression.callee.name === 'skip' ||
+      (
+        node.expression.callee.type === 'MemberExpression' &&
+        node.expression.callee.object.name === 'QUnit' &&
+        node.expression.callee.property.name === 'skip'
+      )
+    );
 }
 
 function hasAssertions(node) {

--- a/tests/fixtures/qunit-files/new-using-qunit-global.js
+++ b/tests/fixtures/qunit-files/new-using-qunit-global.js
@@ -1,0 +1,48 @@
+var thing;
+
+import {module, test, skip} from 'qunit';
+
+QUnit.module('foo-bar/helpers', {
+  beforeEach: function(assert) {
+    assert.ok(true, 'setup worked');
+  },
+  afterEach: function(assert) {
+    assert.ok(true, 'teardown worked');
+  }
+});
+
+QUnit.test('Can do helpery things', function(assert) {
+  function named() {
+    assert.equal('some', 'thing', 'testing equal in a callback');
+  }
+
+  assert.async(1);
+  assert.deepEqual(1);
+  assert.equal(1);
+  assert.expect(1);
+  assert.notDeepEqual(1);
+  assert.notEqual(1);
+  assert.notPropEqual(1);
+  assert.notStrictEqual(1);
+  assert.ok(1);
+  assert.propEqual(1);
+  assert.push(1);
+  assert.strictEqual(1);
+  assert.throws(1);
+});
+
+QUnit.skip('will be skipped', function(assert) {
+  assert.async(1);
+  assert.deepEqual(1);
+  assert.equal(1);
+  assert.expect(1);
+  assert.notDeepEqual(1);
+  assert.notEqual(1);
+  assert.notPropEqual(1);
+  assert.notStrictEqual(1);
+  assert.ok(1);
+  assert.propEqual(1);
+  assert.push(1);
+  assert.strictEqual(1);
+  assert.throws(1);
+});

--- a/tests/fixtures/qunit-files/old-using-qunit-global.js
+++ b/tests/fixtures/qunit-files/old-using-qunit-global.js
@@ -1,0 +1,46 @@
+var thing;
+
+QUnit.module('foo-bar/helpers', {
+  setup: function() {
+    ok(true, 'setup worked');
+  },
+  teardown: function() {
+    ok(true, 'teardown worked');
+  }
+});
+
+QUnit.test('Can do helpery things', function() {
+  function named() {
+    equal('some', 'thing', 'testing equal in a callback');
+  }
+
+  async(1);
+  deepEqual(1);
+  equal(1);
+  expect(1);
+  notDeepEqual(1);
+  notEqual(1);
+  notPropEqual(1);
+  notStrictEqual(1);
+  ok(1);
+  propEqual(1);
+  push(1);
+  strictEqual(1);
+  throws(1);
+});
+
+QUnit.skip('will be skipped', function() {
+  async(1);
+  deepEqual(1);
+  equal(1);
+  expect(1);
+  notDeepEqual(1);
+  notEqual(1);
+  notPropEqual(1);
+  notStrictEqual(1);
+  ok(1);
+  propEqual(1);
+  push(1);
+  strictEqual(1);
+  throws(1);
+});

--- a/tests/qunit-migrator-test.js
+++ b/tests/qunit-migrator-test.js
@@ -14,6 +14,14 @@ describe('Qunit tests with ember-qunit', function() {
 });
 
 describe('Qunit tests only with qunit', function() {
+  it('makes the correct transformations when using QUnit.test', function() {
+    var source = fs.readFileSync('./tests/fixtures/qunit-files/old-using-qunit-global.js');
+    var watson = new Watson();
+    var newSource = watson._transformQUnitTest(source);
+
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/qunit-files/new-using-qunit-global.js'));
+  });
+
   it('makes the correct transformations', function() {
     var source = fs.readFileSync('./tests/fixtures/qunit-files/old-with-qunit.js');
     var watson = new Watson();


### PR DESCRIPTION
This is used in Ember's test suite (and a few apps that I have worked on). This change allows us to run watson against Ember itself to update the tests.