### PR TITLE
Update recast and use esprima as AST parser

### DIFF
--- a/lib/formulas/ember-data-async-false-relationships-transforms.js
+++ b/lib/formulas/ember-data-async-false-relationships-transforms.js
@@ -4,9 +4,10 @@ var recast     = require('recast');
 var builders   = recast.types.builders;
 var types      = recast.types.namedTypes;
 var emberData  = require('./helpers/ember-data');
+var parseAst   = require('../helpers/parse-ast');
 
 module.exports = function transformEmberDataAsyncFalseRelationship(source) {
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
   recast.visit(ast, {
     visitCallExpression: function(path) {

--- a/lib/formulas/ember-data-model-lookup-transform.js
+++ b/lib/formulas/ember-data-model-lookup-transform.js
@@ -7,13 +7,14 @@ var Inflected  = require('inflected');
 var underscore = Inflected.underscore.bind(Inflected);
 var dasherize  = Inflected.dasherize.bind(Inflected);
 var emberData  = require('./helpers/ember-data');
+var parseAst  = require('../helpers/parse-ast');
 
 function normalize(string) {
   return dasherize(underscore(string));
 }
 
 module.exports = function transformEmberDataModelLookups(source){
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
 
   recast.visit(ast, {

--- a/lib/formulas/helpers/add-default-import.js
+++ b/lib/formulas/helpers/add-default-import.js
@@ -1,4 +1,5 @@
 var builders = require('recast').types.builders;
+var parseAst = require('../../helpers/parse-ast');
 
 module.exports = function(ast, moduleName, identifier) {
   var importDefaultSpecifier = [builders.importDefaultSpecifier(
@@ -6,7 +7,7 @@ module.exports = function(ast, moduleName, identifier) {
   )];
   var importDeclaration = builders.importDeclaration(
     importDefaultSpecifier,
-    builders.moduleSpecifier(moduleName)
+    builders.literal(moduleName)
   );
 
   ast.program.body.unshift(importDeclaration);

--- a/lib/formulas/helpers/is-import-for.js
+++ b/lib/formulas/helpers/is-import-for.js
@@ -1,6 +1,6 @@
 var types = require('recast').types.namedTypes;
 
 module.exports = function isImportFor(module, node) {
-  return types.ModuleSpecifier.check(node.source) &&
+  return types.Literal.check(node.source) &&
     node.source.value === module;
 };

--- a/lib/formulas/methodify.js
+++ b/lib/formulas/methodify.js
@@ -2,6 +2,7 @@ var recast      = require('recast');
 var builders    = recast.types.builders;
 var types       = recast.types.namedTypes;
 var isImportFor = require('./helpers/is-import-for');
+var parseAst    = require('../helpers/parse-ast');
 
 function isNotES6Method(node) {
   return types.Property.check(node) &&
@@ -15,7 +16,7 @@ function makeES6Method(path) {
 }
 
 module.exports = function transform(source) {
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
   recast.visit(ast, {
     visitProperty: function(path) {

--- a/lib/formulas/prototype-extension-transforms.js
+++ b/lib/formulas/prototype-extension-transforms.js
@@ -3,6 +3,7 @@ var builders         = recast.types.builders;
 var types            = recast.types.namedTypes;
 var addDefaultImport = require('./helpers/add-default-import');
 var isImportFor      = require('./helpers/is-import-for');
+var parseAst         = require('../helpers/parse-ast');
 
 function hasPrototypeExtensions(sections) {
   return sections.observers.length > 0 ||
@@ -78,7 +79,7 @@ module.exports = function transform(source) {
     addEmberImport: true
   };
 
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
   recast.visit(ast, {
     visitCallExpression: function(path) {

--- a/lib/formulas/qunit-transforms.js
+++ b/lib/formulas/qunit-transforms.js
@@ -2,6 +2,7 @@ var recast      = require('recast');
 var builders    = recast.types.builders;
 var types       = recast.types.namedTypes;
 var isImportFor = require('./helpers/is-import-for');
+var parseAst = require('../helpers/parse-ast');
 
 var ASSERTIONS = [
   'async',
@@ -126,7 +127,7 @@ function addEmberQunitImport(ast, withSkip) {
 
   var emberQUnitImport = builders.importDeclaration(
     specifiers,
-    builders.moduleSpecifier('qunit')
+    builders.literal('qunit')
   );
 
   ast.program.body.unshift(emberQUnitImport);
@@ -143,7 +144,7 @@ module.exports = function transform(source) {
     assertions: []
   };
 
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
   recast.visit(ast, {
     visitExpressionStatement: function(path) {

--- a/lib/formulas/resource-router-mapping.js
+++ b/lib/formulas/resource-router-mapping.js
@@ -3,9 +3,10 @@
 var recast = require('recast');
 var builders = recast.types.builders;
 var types = recast.types.namedTypes;
+var parseAst =  require('../helpers/parse-ast');
 
 module.exports = function transformResourceRouterMapping(source) {
-  var ast = recast.parse(source);
+  var ast = parseAst(source);
 
   recast.visit(ast, {
     visitCallExpression: function (path) {

--- a/lib/helpers/parse-ast.js
+++ b/lib/helpers/parse-ast.js
@@ -1,0 +1,8 @@
+var recast = require('recast');
+var esprima = require('esprima');
+
+module.exports = function(source) {
+  return recast.parse(source, {
+    esprima: esprima
+  });
+};

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.6.0",
+    "esprima": "^2.5.0",
     "inflected": "^1.1.6",
-    "recast": "^0.9.17",
+    "recast": "^0.10.29",
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {

--- a/tests/fixtures/methodify/destructuring-new.js
+++ b/tests/fixtures/methodify/destructuring-new.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { get, set } = Ember;
+
+export default Ember.Route.extend({
+  model() {
+    //some stuff
+  },
+
+  setupController(controller, context) {
+    //some extra stuffs
+    this._super(controller, context);
+  }
+});

--- a/tests/fixtures/methodify/destructuring-old.js
+++ b/tests/fixtures/methodify/destructuring-old.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { get, set } = Ember;
+
+export default Ember.Route.extend({
+  model: function() {
+    //some stuff
+  },
+
+  setupController: function(controller, context) {
+    //some extra stuffs
+    this._super(controller, context);
+  }
+});

--- a/tests/helpers/ast-equality.js
+++ b/tests/helpers/ast-equality.js
@@ -1,6 +1,7 @@
 // Based on Stefan Penner's
 // https://github.com/stefanpenner/esprima-ast-equality
 // only replacing esprima by recast.
+var parseAst = require('../../lib/helpers/parse-ast');
 
 function EqualityError(message, actual, expected) {
   this.message = message;
@@ -18,8 +19,8 @@ var assert = require('assert');
 var recast = require('recast');
 
 module.exports = function(actual, expected, message) {
-  var parsedActual   = recast.parse(actual);
-  var parsedExpected = recast.parse(expected);
+  var parsedActual   = parseAst(actual);
+  var parsedExpected = parseAst(expected);
 
   var seemEqual = JSON.stringify(parsedActual) === JSON.stringify(parsedExpected);
 

--- a/tests/methodify-test.js
+++ b/tests/methodify-test.js
@@ -19,4 +19,12 @@ describe('convert methods to ES6 syntax', function() {
 
     astEquality(newSource, expectedNewSource);
   });
+
+  it('converts to ES6 method syntax and ignores object destructuring', function() {
+    var source = fs.readFileSync(baseDir + '/destructuring-old.js');
+    var newSource = watson._transformMethodify(source);
+    var expectedNewSource = fs.readFileSync(baseDir + '/destructuring-new.js');
+
+    astEquality(newSource, expectedNewSource);
+  });
 });


### PR DESCRIPTION
recast uses by default `esprima-fb` parser, but it's [being deprecated](https://github.com/facebook/esprima/issues/111). And also this implementation doesn't handle some particular cases like using reserved keywords as identifiers in object destructuring statements like `const { get, set } = Ember;`. So this PR changes the default AST parser to esprima and updates the recast version, since the current version doesn't know how to deal with some AST definitions from esprima.

Fixes #70 