### PR TITLE
WIP Lint set chain

### DIFF
--- a/lib/formulas/ember-set-chain-lint.js
+++ b/lib/formulas/ember-set-chain-lint.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var recast     = require('recast');
+var builders   = recast.types.builders;
+var types      = recast.types.namedTypes;
+
+module.exports = function lintEmberSetChain(source){
+  var results = [];
+
+  var ast = recast.parse(source);
+  var sourceLines = source.split(/\r\n?|\n/);
+  var marginWidth = (sourceLines.length + 1).toString().length;
+
+  recast.visit(ast, {
+    visitCallExpression: function(path) {
+      if (isSetCallExpression(path)) {
+        var node = path.node;
+        var parentNode = path.parent.node;
+
+        if (!types.ExpressionStatement.check(parentNode)) {
+          results.push("Using the return value of `set`:\n\n" + getCodeFrame(node));
+        }
+      }
+
+      this.traverse(path);
+    }
+  });
+
+  function isSetCallExpression(path) {
+    var callee = path.node.callee;
+
+    return (
+      types.MemberExpression.check(callee) &&
+      types.Identifier.check(callee.property) &&
+      callee.property.name === 'set'
+    );
+  }
+
+  function getCodeFrame(node) {
+    var nodeStartLine = node.loc.start.line;
+    var nodeEndLine = node.loc.end.line;
+
+    var startLine = Math.max(nodeStartLine - 1, 1);
+    var endLine = Math.min(nodeEndLine + 2, sourceLines.length + 1);
+
+    var codeFrame = "";
+
+    for (var i = startLine; i <= nodeEndLine; i++) {
+      codeFrame += " " + justifyColumn(i) + " | "  + sourceLines[i-1] + "\n";
+    }
+
+    var cursorStart = Math.min(node.loc.start.column, node.loc.end.column);
+    var cursorEnd = Math.max(node.loc.start.column, node.loc.end.column);
+
+    codeFrame += " " + repeat(" ", marginWidth) + " | ";
+    codeFrame += repeat(" ", cursorStart);
+    codeFrame += repeat("^", cursorEnd - cursorStart);
+    codeFrame += "\n";
+
+    for (i = nodeEndLine + 1; i < endLine; i++) {
+      codeFrame += " " + justifyColumn(i) + " | "  + sourceLines[i-1] + "\n";
+    }
+
+    return codeFrame;
+  }
+
+  function repeat(char, times) {
+    var out = "";
+    while (times-- > 0) { out += char; }
+    return out;
+  }
+
+  function justifyColumn(n) {
+    return repeat(" ", marginWidth - n.toString().length) + n;
+  }
+
+  return results;
+};

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -9,6 +9,7 @@ var transformEmberDataModelLookups = require('./formulas/ember-data-model-lookup
 var transformEmberDataAsyncFalseRelationships = require('./formulas/ember-data-async-false-relationships-transforms');
 var transformResourceRouterMapping = require('./formulas/resource-router-mapping');
 var transformMethodify = require('./formulas/methodify');
+var lintEmberSetChain = require('./formulas/ember-set-chain-lint');
 
 
 module.exports = EmberWatson;
@@ -97,3 +98,5 @@ function transform(files, transformFormula) {
 
   return true;
 }
+
+EmberWatson.prototype._lintEmberSetChain = lintEmberSetChain;

--- a/tests/ember-set-chain-lint-test.js
+++ b/tests/ember-set-chain-lint-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var fs     = require('fs');
+var assert = require('assert');
+var Watson = require('../index.js');
+
+describe('ember set chaining lint', function() {
+  var watson;
+
+  function readFixture(path) {
+    var base = './tests/fixtures/ember-set-chain/';
+    return fs.readFileSync(base + path, { encoding: 'utf8' });
+  }
+
+  beforeEach(function() {
+    watson = new Watson();
+  });
+
+  it('reports `set` chaining', function() {
+    var source = readFixture('basic.js');
+    var expectedOutput = readFixture('basic.out');
+    var actualOutput = watson._lintEmberSetChain(source).join('\n');
+    assert.equal(actualOutput, expectedOutput);
+  });
+
+  it('reports multiline `set` chaining', function() {
+    var source = readFixture('multiline.js');
+    var expectedOutput = readFixture('multiline.out');
+    var actualOutput = watson._lintEmberSetChain(source).join('\n');
+    assert.equal(actualOutput, expectedOutput);
+  });
+});

--- a/tests/fixtures/ember-set-chain/basic.js
+++ b/tests/fixtures/ember-set-chain/basic.js
@@ -1,0 +1,7 @@
+function fn() {
+  x.set('foo', 0);
+  x.set('foo', 0).set('bar', 1).set('baz', 2);
+  var y = x.set('foo', 0);
+  for (;x.set('foo', 0);) {};
+  return x.set('foo', 0);
+}

--- a/tests/fixtures/ember-set-chain/basic.out
+++ b/tests/fixtures/ember-set-chain/basic.out
@@ -1,0 +1,34 @@
+Using the return value of `set`:
+
+ 2 |   x.set('foo', 0);
+ 3 |   x.set('foo', 0).set('bar', 1).set('baz', 2);
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 4 |   var y = x.set('foo', 0);
+
+Using the return value of `set`:
+
+ 2 |   x.set('foo', 0);
+ 3 |   x.set('foo', 0).set('bar', 1).set('baz', 2);
+   |   ^^^^^^^^^^^^^^^
+ 4 |   var y = x.set('foo', 0);
+
+Using the return value of `set`:
+
+ 3 |   x.set('foo', 0).set('bar', 1).set('baz', 2);
+ 4 |   var y = x.set('foo', 0);
+   |           ^^^^^^^^^^^^^^^
+ 5 |   for (;x.set('foo', 0);) {};
+
+Using the return value of `set`:
+
+ 4 |   var y = x.set('foo', 0);
+ 5 |   for (;x.set('foo', 0);) {};
+   |         ^^^^^^^^^^^^^^^
+ 6 |   return x.set('foo', 0);
+
+Using the return value of `set`:
+
+ 5 |   for (;x.set('foo', 0);) {};
+ 6 |   return x.set('foo', 0);
+   |          ^^^^^^^^^^^^^^^
+ 7 | }

--- a/tests/fixtures/ember-set-chain/multiline.js
+++ b/tests/fixtures/ember-set-chain/multiline.js
@@ -1,0 +1,9 @@
+function fn() {
+  x.set('foo', 0)
+   .set('bar', 1)
+   .set('baz', 2);
+
+  x.set('foo', {
+    a: 0
+  }).set('bar', 1);
+}

--- a/tests/fixtures/ember-set-chain/multiline.out
+++ b/tests/fixtures/ember-set-chain/multiline.out
@@ -1,0 +1,23 @@
+Using the return value of `set`:
+
+  1 | function fn() {
+  2 |   x.set('foo', 0)
+  3 |    .set('bar', 1)
+    |   ^^^^^^^^^^^^^^^
+  4 |    .set('baz', 2);
+
+Using the return value of `set`:
+
+  1 | function fn() {
+  2 |   x.set('foo', 0)
+    |   ^^^^^^^^^^^^^^^
+  3 |    .set('bar', 1)
+
+Using the return value of `set`:
+
+  5 | 
+  6 |   x.set('foo', {
+  7 |     a: 0
+  8 |   }).set('bar', 1);
+    |   ^^
+  9 | }


### PR DESCRIPTION
This tool is intended to help out with https://github.com/emberjs/ember.js/issues/12095.

The point of the tool is to list all places where you may be using Ember.set of obj.set in a sketchy way, so that you can manually audit them.

It would be nice to give ember-watson first class support for linting instead of only source-to-source transformation. We might want to use JSCS because it has great support for displaying the offending code.
