### PR TITLE
Add command for finding old-style CPs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,6 +56,16 @@ program
     watson.transformMethodify(path);
   });
 
+program
+  .command('find-overloaded-cps [path]')
+  .option('-j, --json', 'Output in JSON instead of pretty print.')
+  .description('This lists all the places that will trigger the "Using the same function as getter and setter" deprecation.')
+  .action(function(path, options) {
+    path = path || 'app';
+    watson.findOverloadedCPs(path).outputSummary(options.json ? 'json' : 'pretty');
+  });
+
+
 module.exports = function init(args) {
   program.parse(args);
 };

--- a/lib/commands/find-overloaded-cps.js
+++ b/lib/commands/find-overloaded-cps.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var Watson = require('../../index');
+var watson = new Watson();
+
+module.exports = {
+  name: 'watson:find-overloaded-cps',
+  description: 'This lists all the places that will trigger the "Using the same function as getter and setter" deprecation.',
+  works: 'insideProject',
+  anonymousOptions: [
+    '<path>'
+  ],
+  run: function(commandOptions, rawArgs) {
+    var path = rawArgs[0] ||  'app';
+    var reportFormat = commandOptions.json ? 'json' : 'pretty';
+    watson.findOverloadedCPs(path).outputSummary(reportFormat);
+  }
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -6,5 +6,6 @@ module.exports = {
   'watson:convert-ember-data-model-lookups': require('./convert-ember-data-model-lookups'),
   'watson:convert-ember-data-async-false-relationships': require('./convert-ember-data-async-false-relationships'),
   'watson:methodify': require('./methodify'),
-  'watson:convert-resource-router-mapping': require('./convert-resource-router-mapping')
+  'watson:convert-resource-router-mapping': require('./convert-resource-router-mapping'),
+  'watson:find-overloaded-cps': require('./find-overloaded-cps')
 };

--- a/lib/formulas/find-overloaded-cps.js
+++ b/lib/formulas/find-overloaded-cps.js
@@ -1,0 +1,78 @@
+var recast      = require('recast');
+var types       = recast.types.namedTypes;
+var parseAst    = require('../helpers/parse-ast');
+var chalk     = require('chalk');
+
+function Searcher(reportFormat) {
+  this.reportFormat = reportFormat;
+  this.findings = [];
+  this.sources = {};
+}
+
+function isPrototypeExtendedCP(node){
+  return types.MemberExpression.check(node.callee) &&
+    types.Identifier.check(node.callee.property) &&
+    node.callee.property.name === 'property' &&
+    types.FunctionExpression.check(node.callee.object);
+}
+
+function moreThanArityOne(node) {
+  return types.FunctionExpression.check(node) && node.params.length > 1;
+}
+
+function isFunctionExpressionCP(node) {
+  return node.callee.name === 'computed' || (
+    node.callee.type === 'MemberExpression' &&
+      node.callee.property.name === 'computed'
+  );
+}
+
+function any(list, predicate) {
+  for (var i = 0; i < list.length; i++) {
+    if (predicate(list[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Searcher.prototype.examineSource = function(source, filename) {
+  var ast = parseAst(source);
+  var searcher = this;
+  recast.visit(ast, {
+    visitCallExpression: function(path) {
+      if ((isPrototypeExtendedCP(path.node) && moreThanArityOne(path.node.callee.object)) ||
+          (isFunctionExpressionCP(path.node) && any(path.node.arguments, moreThanArityOne))
+         ) {
+        searcher.sources[filename] = source.toString();
+        searcher.findings.push({
+          filename: filename,
+          loc: {
+            start: path.node.loc.start,
+            end: path.node.loc.end
+          }
+        });
+         }
+      this.traverse(path);
+    }
+  });
+};
+
+Searcher.prototype.outputSummary = function(reportFormat) {
+  if (reportFormat === 'json') {
+    console.log(JSON.stringify(this.findings, null, 2));
+    return;
+  }
+  var searcher = this;
+  this.findings.forEach(function(finding) {
+    searcher.printFinding(finding);
+  });
+};
+
+Searcher.prototype.printFinding = function(finding) {
+  console.log(chalk.green(finding.filename + ':' + finding.loc.start.line));
+  var lines = this.sources[finding.filename].split(/\r|\n/).slice(finding.loc.start.line - 1, finding.loc.end.line);
+  console.log(lines.join("\n"));
+};
+
+module.exports = Searcher;

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -9,7 +9,7 @@ var transformEmberDataModelLookups = require('./formulas/ember-data-model-lookup
 var transformEmberDataAsyncFalseRelationships = require('./formulas/ember-data-async-false-relationships-transforms');
 var transformResourceRouterMapping = require('./formulas/resource-router-mapping');
 var transformMethodify = require('./formulas/methodify');
-
+var FindOverloadedCPs = require('./formulas/find-overloaded-cps');
 
 module.exports = EmberWatson;
 
@@ -62,13 +62,22 @@ EmberWatson.prototype.transformResourceRouterMapping = function(routerPath) {
   transform([routerPath], this._transformResourceRouterMapping);
 };
 
+EmberWatson.prototype.findOverloadedCPs = function(rootPath) {
+  var searcher = new FindOverloadedCPs();
+  transform(findFiles(rootPath, '.js'), function(source, filename) {
+    searcher.examineSource(source, filename);
+    return source;
+  });
+  return searcher;
+};
+
 function transform(files, transformFormula) {
   var wontFix = [];
 
   files.forEach(function(file) {
     var source = fs.readFileSync(file);
     try {
-      var newSource = transformFormula(source);
+      var newSource = transformFormula(source, file);
       if (source != newSource) {
         console.log(chalk.green('Fixed: ', file));
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {
+    "chai": "^3.2.0",
     "esprima-ast-equality": "0.0.4",
     "mocha": "^2.1.0",
     "mocha-jshint": "0.0.9",

--- a/tests/find-overloaded-cps-test.js
+++ b/tests/find-overloaded-cps-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var Watson      = require('../index.js');
+var fs          = require('fs');
+var chai        = require('chai');
+
+describe('find overloaded CPs', function() {
+  var baseDir = './tests/fixtures/find-overloaded-cps';
+  var watson;
+
+  beforeEach(function() {
+    watson = new Watson();
+  });
+
+  it('has expected JSON output', function() {
+    var searcher = watson.findOverloadedCPs(baseDir + '/input');
+    var expectedReport = JSON.parse(fs.readFileSync(baseDir + '/output/report.json'));
+    chai.expect(searcher.findings).to.deep.equal(expectedReport);
+  });
+
+});

--- a/tests/fixtures/find-overloaded-cps/input/sample.js
+++ b/tests/fixtures/find-overloaded-cps/input/sample.js
@@ -1,0 +1,20 @@
+/* jshint esnext: true */
+
+import Ember from 'ember';
+var Em = Ember;
+var computed = Ember.computed;
+
+Ember.Component.extend({
+  first: Ember.computed(function(k, v) {}),
+  second: Em.computed('first', function(k, v) { }),
+  third: computed('second', function(k, v) { }),
+  fourth: function(k, v) { }.property('third'),
+
+
+  firstLegal: Ember.computed(function() {}),
+  secondLegal: Em.computed('first', function() { }),
+  thirdLegal: computed('second', function() { }),
+  fourthLegal: function() { }.property('third')
+
+
+});

--- a/tests/fixtures/find-overloaded-cps/output/report.json
+++ b/tests/fixtures/find-overloaded-cps/output/report.json
@@ -1,0 +1,54 @@
+[
+  {
+    "filename": "tests/fixtures/find-overloaded-cps/input/sample.js",
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 9
+      },
+      "end": {
+        "line": 8,
+        "column": 42
+      }
+    }
+  },
+  {
+    "filename": "tests/fixtures/find-overloaded-cps/input/sample.js",
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 10
+      },
+      "end": {
+        "line": 9,
+        "column": 50
+      }
+    }
+  },
+  {
+    "filename": "tests/fixtures/find-overloaded-cps/input/sample.js",
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 9
+      },
+      "end": {
+        "line": 10,
+        "column": 47
+      }
+    }
+  },
+  {
+    "filename": "tests/fixtures/find-overloaded-cps/input/sample.js",
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 10
+      },
+      "end": {
+        "line": 11,
+        "column": 46
+      }
+     }
+  }
+]


### PR DESCRIPTION
This adds `ember watson:find-overloaded-cps` for help locating all the places where your source may trigger the "Using the same function as getter and setter" deprecation, which is otherwise hard to statically search for.

Unlike the other commands, this one is purely advisory, it does not attempt to edit your source. By default it outputs a colored report showing the snippets of code that are probably deprecated CPs. You can optionally pass `--json` to get a json representation instead.