### PR TITLE
Shows the help if the command is wrong or empty

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,14 +4,40 @@ var program = require('commander');
 var Watson = require('./watson');
 var watson = new Watson();
 var version = require('../package.json').version;
+var supportedCommands = ['upgrade-qunit-tests', 'convert-prototype-extensions',
+                      'convert-prototype-extensions', 'convert-ember-data-model-lookups',
+                      'convert-ember-data-async-false-relationships', 'convert-resource-router-mapping',
+                      'methodify', 'find-overloaded-cps', 'use-destroy-app-helper'
+                    ];
+
+var isSupportedCommands = function(command) {
+
+  for (var i = 0; i < supportedCommands.length; i++) {
+    if (command === supportedCommands[i]) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 program
   .version(version);
 
 program
+  .arguments('<cmd>')
+  .action(function(cmd) {
+    if (!isSupportedCommands(cmd)) {
+      console.error('The command is not supported, Use the below supported commands');
+      program.outputHelp();
+      process.exit(1);
+    }
+  });
+
+program
   .command('upgrade-qunit-tests [testsPath]')
   .description('Fix QUnit tests to match 2.0 syntax. testsPath defaults to tests/')
-  .action(function(testsPath){
+  .action(function(testsPath) {
     testsPath = testsPath || 'tests';
     watson.transformQUnitTest(testsPath);
   });
@@ -19,7 +45,7 @@ program
 program
   .command('convert-prototype-extensions [appPath]')
   .description('Convert computed properties and observers to not use prototype extensions. appPath defaults to app/')
-  .action(function(appPath){
+  .action(function(appPath) {
     appPath = appPath || 'app';
     watson.transformPrototypeExtensions(appPath);
   });
@@ -75,4 +101,7 @@ program
 
 module.exports = function init(args) {
   program.parse(args);
+  if (!process.argv.slice(2).length) {
+    program.outputHelp();
+  }
 };


### PR DESCRIPTION
This PR will show up the Help generated by commander when ever an non-supported command has been triggered( Mosted cases it happens for me because of typo.)

And also times when there is no command provided.

Say,

``` bash
$ember-watson non-supported-command

The command is not supported, Use the below supported commands

  Usage: ember-watson [options] [command] <cmd>


  Commands:

    upgrade-qunit-tests [testsPath]                         Fix QUnit tests to match 2.0 syntax. testsPath defaults to tests/
    convert-prototype-extensions [appPath]                  Convert computed properties and observers to not use prototype extensions. appPath defaults to app/
    convert-ember-data-model-lookups [appPath]              convert Ember Data model lookups to use a dasherized string
    convert-ember-data-async-false-relationships [appPath]  convert Ember Data relationship with implicit async: false to explicit option
    convert-resource-router-mapping [routerPath]            convert the resource router mapping to use the route mapping with the new resetNamespace option
    methodify [path]                                        Convert methods to new ES6 syntax
    find-overloaded-cps [options] [path]                    This lists all the places that will trigger the "Using the same function as getter and setter" deprecation.

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

```

and  for just `ember-watson` 

``` bash
$ember-watson

Usage: ember-watson [options] [command] <cmd>


  Commands:

    upgrade-qunit-tests [testsPath]                         Fix QUnit tests to match 2.0 syntax. testsPath defaults to tests/
    convert-prototype-extensions [appPath]                  Convert computed properties and observers to not use prototype extensions. appPath defaults to app/
    convert-ember-data-model-lookups [appPath]              convert Ember Data model lookups to use a dasherized string
    convert-ember-data-async-false-relationships [appPath]  convert Ember Data relationship with implicit async: false to explicit option
    convert-resource-router-mapping [routerPath]            convert the resource router mapping to use the route mapping with the new resetNamespace option
    methodify [path]                                        Convert methods to new ES6 syntax
    find-overloaded-cps [options] [path]                    This lists all the places that will trigger the "Using the same function as getter and setter" deprecation.

  Options:

    -h, --help     output usage information
    -V, --version  output the version number
```

Feel free to add add suggestions or reject this PR if not needed.
