### PR TITLE
Add a command to replace needs with injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Convert (qunit or mocha flavored) acceptance tests to utilize the `destroyApp`
 helper [introduced](https://github.com/ember-cli/ember-cli/pull/4772) in
 Ember CLI 1.13.9.
 
+#### `ember watson:replace-needs-with-injection <path>`
+
+Convert `needs` declarations the individual properties using the new `Ember.inject.controller()` feature. Also convert any uses of the `controllers` hash to use the newly defined properties.
+
 ### Specifying a file or path.
 
 You can run any of the commands passing as argument the path, file or

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -73,6 +73,14 @@ program
     watson.transformTestToUseDestroyApp(path);
   });
 
+program
+  .command('replace-needs-with-injection [path]')
+  .description('Replace needs with controller injection.')
+  .action(function(path) {
+    path = path || 'app';
+    watson.replaceNeedsWithInjection(path);
+  });
+
 module.exports = function init(args) {
   program.parse(args);
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -8,5 +8,6 @@ module.exports = {
   'watson:methodify': require('./methodify'),
   'watson:convert-resource-router-mapping': require('./convert-resource-router-mapping'),
   'watson:find-overloaded-cps': require('./find-overloaded-cps'),
-  'watson:use-destroy-app-helper': require('./use-destroy-app-helper')
+  'watson:use-destroy-app-helper': require('./use-destroy-app-helper'),
+  'watson:replace-needs-with-injection': require('./replace-needs-with-injection')
 };

--- a/lib/commands/replace-needs-with-injection.js
+++ b/lib/commands/replace-needs-with-injection.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var Watson = require('../../index');
+var watson = new Watson();
+
+module.exports = {
+  name: 'watson:replace-needs-with-injection',
+  description: 'Replace needs with controller injection.',
+  works: 'insideProject',
+  anonymousOptions: [
+    '<path>'
+  ],
+  run: function(commandOptions, rawArgs) {
+    var path = rawArgs[0] || 'app/controllers';
+    watson.replaceNeedsWithInjection(path);
+  }
+};

--- a/lib/formulas/replace-needs-with-injection.js
+++ b/lib/formulas/replace-needs-with-injection.js
@@ -1,0 +1,154 @@
+var parseAst    = require('../helpers/parse-ast');
+var recast      = require('recast');
+var b    = recast.types.builders;
+var isImportFor = require('./helpers/is-import-for');
+var addDefaultImport = require('./helpers/add-default-import');
+
+module.exports = function transform(source) {
+  var ast = parseAst(source);
+  var needs, emberImport;
+  var uses = [];
+  recast.visit(ast, {
+    visitProperty: function(path) {
+      if(isNeedsDeclaration(path)) {
+        needs = path;
+        return false;
+      }
+      this.traverse(path);
+    },
+    visitLiteral: function(path) {
+      if (isNeedsUsage(path)) {
+        uses.push(path);
+      }
+      this.traverse(path);
+    },
+    visitImportDeclaration: function(path) {
+      if (isImportFor('ember', path.node)) {
+        emberImport = path;
+      }
+      this.traverse(path);
+    },
+  });
+
+  transformNeeds(ast, needs, uses, emberImport);
+  return recast.print(ast, { tabWidth: 2, quote: 'single' }).code;
+};
+
+function transformNeeds(ast, needs, uses, emberImport) {
+  if (needs) {
+    // What is Ember imported as?
+    var emberIdentifier = getEmberImportName(ast, emberImport);
+    // Get a normal array of needs names
+    var needsArray = normaliseNeeds(needs);
+    // Generate a map from controller path to new property names
+    var newKeysMap = generateNewKeysMap(needsArray);
+    // Update the paths
+    replaceNeedsProperty(emberIdentifier, needs, newKeysMap);
+    if (uses.length > 0) {
+      transformUses(uses, newKeysMap);
+    }
+  }
+}
+
+var replaceNeedsProperty = function(emberIdentifier, path, newKeyMap) {
+  var replacements = [];
+  if (path.value.value.elements) {
+    path.value.value.elements.forEach(function(element) {
+      path.parentPath.unshift(buildInjectionExpression(emberIdentifier, element.value, newKeyMap));
+    });
+    path.replace();
+  } else {
+    path.replace(buildInjectionExpression(emberIdentifier, path.value.value.value, newKeyMap));
+  }
+};
+
+var transformUses = function(paths, newKeyMap) {
+  paths.forEach(function(path) {
+    for(var prop in newKeyMap) {
+      var regex = new RegExp('controllers\\.' + prop + '(\\.|$)');
+      var match = path.value.value.match(regex);
+      if (match) {
+        var newLiteral = path.value.value.replace(regex, newKeyMap[prop] + match[1]);
+        path.replace(b.literal(newLiteral));
+      }
+    }
+  });
+};
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function invertMap(map) {
+  var invertedMap = {};
+  for(var prop in map) {
+    if(map.hasOwnProperty(prop)) {
+      invertedMap[map[prop]] = prop;
+    }
+  }
+  return invertedMap;
+}
+
+var generateNewKeysMap = function(needsArray) {
+  var newKeys = {};
+  needsArray.forEach(function(needsNode) {
+    var needsValue = needsNode.value;
+    var needsParts = needsValue.split('/');
+    var key = 'Controller';
+    do {
+      key = capitalizeFirstLetter(key);
+      key = needsParts.pop().replace(/-/g, '') + key;
+    } while(newKeys[key] !== undefined);
+    newKeys[key] = needsValue;
+  });
+  return invertMap(newKeys);
+};
+
+function isNeedsUsage(path) {
+  return path &&
+    path.value &&
+    typeof path.value.value === 'string' &&
+    path.value.value.indexOf('controllers.') === 0;
+}
+
+function isNeedsDeclaration(path) {
+  return path.value.key.name === 'needs';
+}
+
+function normaliseNeeds(needs) {
+  var needsArray = needs.value.value.elements;
+  if (needsArray === undefined) {
+    needsArray = [needs.value.value];
+  }
+  return needsArray;
+}
+
+function getEmberImportName(ast, emberImport) {
+  if (!emberImport) {
+    addDefaultImport(ast, 'ember', 'Ember');
+    emberIdentifier = 'Ember';
+  } else {
+    emberIdentifier = emberImport.value.specifiers[0].local.name;
+  }
+  return emberIdentifier;
+}
+
+var buildInjectionExpression = function(emberIdentifier, controllerPath, newKeyMap) {
+  var name = newKeyMap[controllerPath];
+  return b.property(
+    'init',
+    b.identifier(name),
+    b.callExpression(
+      b.memberExpression(
+        b.identifier(emberIdentifier),
+        b.memberExpression(
+          b.identifier("inject"),
+          b.identifier("controller"),
+          false
+        ),
+        false
+      ),
+      [b.literal(controllerPath)]
+    )
+  );
+};

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -13,6 +13,7 @@ var transformResourceRouterMapping = require('./formulas/resource-router-mapping
 var transformMethodify = require('./formulas/methodify');
 var FindOverloadedCPs = require('./formulas/find-overloaded-cps');
 var transformDestroyApp = require('./formulas/destroy-app-transform');
+var replaceNeedsWithInjection = require('./formulas/replace-needs-with-injection');
 
 module.exports = EmberWatson;
 
@@ -66,6 +67,13 @@ EmberWatson.prototype.transformResourceRouterMapping = function(routerPath) {
 };
 
 EmberWatson.prototype._transformDestroyApp = transformDestroyApp;
+
+EmberWatson.prototype.replaceNeedsWithInjection = function(path) {
+  var files = findFiles(path, '.js');
+  transform(files, this._replaceNeedsWithInjection);
+};
+
+EmberWatson.prototype._replaceNeedsWithInjection = replaceNeedsWithInjection;
 
 EmberWatson.prototype.transformTestToUseDestroyApp = function(rootPath) {
   if (!existsSync('tests/helpers/destroy-app.js')) {

--- a/tests/fixtures/replace-needs-with-injection/array-result.js
+++ b/tests/fixtures/replace-needs-with-injection/array-result.js
@@ -1,0 +1,6 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  barController: Em.inject.controller('bar'),
+  fooController: Em.inject.controller('foo')
+});

--- a/tests/fixtures/replace-needs-with-injection/array.js
+++ b/tests/fixtures/replace-needs-with-injection/array.js
@@ -1,0 +1,5 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  needs: ['foo', 'bar']
+});

--- a/tests/fixtures/replace-needs-with-injection/duplicate-names-result.js
+++ b/tests/fixtures/replace-needs-with-injection/duplicate-names-result.js
@@ -1,0 +1,6 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  fooBarController: Em.inject.controller('foo/bar'),
+  bazBarController: Em.inject.controller('baz/bar')
+});

--- a/tests/fixtures/replace-needs-with-injection/duplicate-names.js
+++ b/tests/fixtures/replace-needs-with-injection/duplicate-names.js
@@ -1,0 +1,8 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  needs: [
+    'foo/bar',
+    'baz/bar'
+  ]
+});

--- a/tests/fixtures/replace-needs-with-injection/no-ember-import-result.js
+++ b/tests/fixtures/replace-needs-with-injection/no-ember-import-result.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import SomeBaseController from 'somewhere';
+
+export default SomeBaseController.extend({
+  fooController: Ember.inject.controller('foo')
+});

--- a/tests/fixtures/replace-needs-with-injection/no-ember-import.js
+++ b/tests/fixtures/replace-needs-with-injection/no-ember-import.js
@@ -1,0 +1,5 @@
+import SomeBaseController from 'somewhere';
+
+export default SomeBaseController.extend({
+  needs: ['foo']
+});

--- a/tests/fixtures/replace-needs-with-injection/single-result.js
+++ b/tests/fixtures/replace-needs-with-injection/single-result.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  fooController: Ember.inject.controller('foo')
+});

--- a/tests/fixtures/replace-needs-with-injection/single.js
+++ b/tests/fixtures/replace-needs-with-injection/single.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  needs: 'foo'
+});

--- a/tests/fixtures/replace-needs-with-injection/uses-result.js
+++ b/tests/fixtures/replace-needs-with-injection/uses-result.js
@@ -1,0 +1,7 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  fooController: Em.inject.controller('foo'),
+  fooModel: Em.computed.alias('fooController.model'),
+  computedFoo: Em.computed('fooController', function() {})
+});

--- a/tests/fixtures/replace-needs-with-injection/uses.js
+++ b/tests/fixtures/replace-needs-with-injection/uses.js
@@ -1,0 +1,7 @@
+import Em from 'ember';
+
+export default Ember.Controller.extend({
+  needs: ['foo'],
+  fooModel: Em.computed.alias('controllers.foo.model'),
+  computedFoo: Em.computed('controllers.foo', function() {})
+});

--- a/tests/replace-needs-with-injection-test.js
+++ b/tests/replace-needs-with-injection-test.js
@@ -1,0 +1,41 @@
+var Watson = require('../index.js');
+var fs = require('fs');
+var astEquality = require('./helpers/ast-equality');
+
+describe('replacing deprecated needs with controller injection', function() {
+
+  it('replaces single needs', function() {
+    var source = fs.readFileSync('./tests/fixtures/replace-needs-with-injection/single.js');
+    var watson = new Watson();
+    var newSource = watson._replaceNeedsWithInjection(source);
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/replace-needs-with-injection/single-result.js'));
+  });
+
+  it('replaces needs arrays', function() {
+    var source = fs.readFileSync('./tests/fixtures/replace-needs-with-injection/array.js');
+    var watson = new Watson();
+    var newSource = watson._replaceNeedsWithInjection(source);
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/replace-needs-with-injection/array-result.js'));
+  });
+
+  it('dedupes controller names', function() {
+    var source = fs.readFileSync('./tests/fixtures/replace-needs-with-injection/array.js');
+    var watson = new Watson();
+    var newSource = watson._replaceNeedsWithInjection(source);
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/replace-needs-with-injection/array-result.js'));
+  });
+
+  it('replaces uses', function() {
+    var source = fs.readFileSync('./tests/fixtures/replace-needs-with-injection/uses.js');
+    var watson = new Watson();
+    var newSource = watson._replaceNeedsWithInjection(source);
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/replace-needs-with-injection/uses-result.js'));
+  });
+
+  it('adds an import if needed', function() {
+    var source = fs.readFileSync('./tests/fixtures/replace-needs-with-injection/no-ember-import.js');
+    var watson = new Watson();
+    var newSource = watson._replaceNeedsWithInjection(source);
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/replace-needs-with-injection/no-ember-import-result.js'));
+  });
+});


### PR DESCRIPTION
Relates to https://github.com/abuiles/ember-watson/issues/85

Replace:
```javascript
needs: ['foo'],
fooModel: Em.computed.alias('controllers.foo.model')
```

With
```
fooController: Em.inject.controller('foo'),
fooModel: Em.computed.alias('fooController.model')
```

I had a need for this in our internal project so I took it on today. I'm completely new to the recast AST API so I may be using it sub-optimally. Also some of the decisions I've made with regard to renaming might only make sense in the context of our project.

I was unsure how to approach the template aspect of this so I've ignored it.

I'm happy to change anything that seems incorrect.