### PR TITLE
arrow functions without assert are rewritten w/assert

### DIFF
--- a/lib/formulas/qunit-transforms.js
+++ b/lib/formulas/qunit-transforms.js
@@ -103,7 +103,7 @@ function transformTestStatement(node) {
 }
 
 function transformTestCallback(callback){
-  if (types.FunctionExpression.check(callback)) {
+  if (types.FunctionExpression.check(callback) || types.ArrowFunctionExpression.check(callback)) {
     if (callback.params.length === 0) {
       callback.params.push(builders.identifier('assert'));
     }
@@ -115,7 +115,6 @@ function transformAssertions(node) {
 }
 
 function addEmberQunitImport(ast, withSkip) {
-  var firstImport = ast.program.body.shift();
   var specifiers = [
     builders.importSpecifier(builders.identifier('module')),
     builders.importSpecifier(builders.identifier('test'))
@@ -131,7 +130,6 @@ function addEmberQunitImport(ast, withSkip) {
   );
 
   ast.program.body.unshift(emberQUnitImport);
-  ast.program.body.unshift(firstImport);
 }
 
 
@@ -181,6 +179,10 @@ module.exports = function transform(source) {
     }
   });
 
+  if (sections.addQUnitImport) {
+    addEmberQunitImport(ast, sections.skips.length > 0);
+  }
+
   sections.modules.forEach(function(qunitModule) {
     transformModule(qunitModule);
   });
@@ -196,10 +198,6 @@ module.exports = function transform(source) {
   sections.assertions.forEach(function(node) {
     transformAssertions(node);
   });
-
-  if (sections.addQUnitImport) {
-    addEmberQunitImport(ast, sections.skips.length > 0);
-  }
 
   return recast.print(ast, { tabWidth: 2, quote: 'single' }).code;
 };

--- a/tests/fixtures/qunit-files/arrowfunction-new.js
+++ b/tests/fixtures/qunit-files/arrowfunction-new.js
@@ -1,0 +1,13 @@
+import {module, test} from 'qunit';
+module('testing arrow functions', {
+  beforeEach: function(){
+    console.log('starting');
+  },
+  afterEach: function(){
+    console.log('done');
+  }
+});
+
+test('this function should have assert when translated', assert => {
+  assert.ok(true);
+});

--- a/tests/fixtures/qunit-files/arrowfunction-old.js
+++ b/tests/fixtures/qunit-files/arrowfunction-old.js
@@ -1,0 +1,12 @@
+module('testing arrow functions', {
+  setup: function(){
+    console.log('starting');
+  },
+  teardown: function(){
+    console.log('done');
+  }
+});
+
+test('this function should have assert when translated', () => {
+  ok(true);
+});

--- a/tests/fixtures/qunit-files/new-using-qunit-global.js
+++ b/tests/fixtures/qunit-files/new-using-qunit-global.js
@@ -1,6 +1,5 @@
-var thing;
-
 import {module, test, skip} from 'qunit';
+var thing;
 
 QUnit.module('foo-bar/helpers', {
   beforeEach: function(assert) {

--- a/tests/fixtures/qunit-files/new-with-qunit-and-skip.js
+++ b/tests/fixtures/qunit-files/new-with-qunit-and-skip.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import {module, test, skip} from 'qunit';
+import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import Pretender from 'pretender';
 

--- a/tests/fixtures/qunit-files/new-with-qunit.js
+++ b/tests/fixtures/qunit-files/new-with-qunit.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import {module, test} from 'qunit';
+import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import Pretender from 'pretender';
 

--- a/tests/qunit-migrator-test.js
+++ b/tests/qunit-migrator-test.js
@@ -45,4 +45,12 @@ describe('Qunit tests only with qunit', function() {
 
     astEquality(newSource, fs.readFileSync('./tests/fixtures/qunit-files/new-with-qunit.js'));
   });
+
+  it('transforms `test` calls with arrow functions to pass `assert` as first argument', function() {
+    var source = fs.readFileSync('./tests/fixtures/qunit-files/arrowfunction-old.js');
+    var watson = new Watson();
+    var newSource = watson._transformQUnitTest(source);
+
+    astEquality(newSource, fs.readFileSync('./tests/fixtures/qunit-files/arrowfunction-new.js'));
+  });
 });


### PR DESCRIPTION
for example:

```javascript
test('something', () => {

});
```

becomes:

```javascript
test('something', assert => {

});
```