### PR TITLE
One command to run them all

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -81,6 +81,27 @@ program
     watson.replaceNeedsWithInjection(path);
   });
 
+program
+  .command('all')
+  .option('--tests-path [path]', 'Path to tests directory.', 'tests')
+  .option('--app-path [path]', 'Path to app directory.', 'app')
+  .option('--router-path [path]', 'Path to router file.', 'app/router.js')
+  .option('--acceptance-path [path]', 'Path to acceptance tests directory.', 'tests/acceptance')
+  .option('--controllers-path [path]', 'Path to controllers directory.', 'app/controllers')
+  .option('--output [format]', 'Output format: pretty or json.', 'pretty')
+  .description('Run all commands.')
+  .action(function(options) {
+    watson.transformQUnitTest(options.testsPath);
+    watson.transformPrototypeExtensions(options.appPath);
+    watson.transformEmberDataModelLookups(options.appPath);
+    watson.transformEmberDataAsyncFalseRelationships(options.appPath);
+    watson.transformResourceRouterMapping(options.routerPath);
+    watson.transformMethodify(options.appPath);
+    watson.findOverloadedCPs(options.appPath).outputSummary(options.output);
+    watson.transformTestToUseDestroyApp(options.acceptancePath);
+    watson.replaceNeedsWithInjection(options.controllersPath);
+  });
+
 module.exports = function init(args) {
   program.parse(args);
 };

--- a/lib/commands/all.js
+++ b/lib/commands/all.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var Watson = require('../../index');
+var watson = new Watson();
+
+module.exports = {
+  name: 'watson:all',
+  description: 'Performs all available Watson commands on a project.',
+  works: 'insideProject',
+  availableOptions: [
+    { name: 'app-path', type: String, description: 'Path to app directory.', default: 'app' },
+    { name: 'tests-path', type: String, description: 'Path to tests directory.', default: 'tests' },
+    { name: 'router-path', type: String, description: 'Path to router file.', default: 'app/router.js' },
+    { name: 'output', type: String, description: 'Output format: pretty or json.', default: 'pretty' },
+    { name: 'acceptance-path', type: String, description: 'Path to acceptance tests directory.', default: 'tests/acceptance' },
+    { name: 'controllers-path', type: String, description: 'Path to controllers directory.', default: 'app/controllers' },
+  ],
+  run: function(options) {
+    watson.transformQUnitTest(options.testsPath);
+    watson.transformPrototypeExtensions(options.appPath);
+    watson.transformEmberDataModelLookups(options.appPath);
+    watson.transformEmberDataAsyncFalseRelationships(options.appPath);
+    watson.transformResourceRouterMapping(options.routerPath);
+    watson.transformMethodify(options.appPath);
+    watson.findOverloadedCPs(options.appPath).outputSummary(options.output);
+    watson.transformTestToUseDestroyApp(options.acceptancePath);
+    watson.replaceNeedsWithInjection(options.controllersPath);
+  }
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  'watson:all': require('./all'),
   'watson:upgrade-qunit-tests': require('./upgrade-qunit-tests'),
   'watson:convert-prototype-extensions': require('./convert-prototype-extensions'),
   'watson:convert-ember-data-model-lookups': require('./convert-ember-data-model-lookups'),


### PR DESCRIPTION
I recently had a good discussion with @abuiles regarding some changes I was planning on contributing to `ember-watson` in order to <a href="https://github.com/abuiles/ember-watson/issues/81">make ember-watson Code Climate and cli friendly</a> and this is the first - a command to run all of the ember-watson commands.

I figured I'd open this PR since it's been a while since I dug into this repo. Feedback is welcome and I will expand test coverage if people are generally +1 on this approach.

I'm also working on a `dry-run` mode which will output fixes instead of applying them.