### PR TITLE
add remove-ember-data-is-new-serializer-api command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A young Ember Doctor.
 * [find-overloaded-cps](#ember-watsonfind-overloaded-cps-path)
 * [use-destroy-app-helper](#ember-watsonuse-destroy-app-helper-path)
 * [replace-needs-with-injection](#ember-watsonreplace-needs-with-injection-path)
+* [remove-ember-data-is-new-serializer-api](#ember-watson-remove-ember-data-is-new-serializer-api)
 
 ## Using as an ember CLI addon
 
@@ -112,6 +113,26 @@ Ember CLI 1.13.9.
 #### `ember watson:replace-needs-with-injection <path>`
 
 Convert `needs` declarations the individual properties using the new `Ember.inject.controller()` feature. Also convert any uses of the `controllers` hash to use the newly defined properties.
+
+### `ember watson:remove-ember-data-is-new-serializer-api`
+
+Removes `isNewSerializerAPI` literals in your serializer code.
+You should use this *after* you make sure all your serializers are
+compatible with the new serializer API in 1.13. You can find more
+information on how to upgrade serializers
+[here](http://emberjs.com/blog/2015/06/18/ember-data-1-13-released.html#toc_transition-to-the-new-jsonserializer-and-restserializer-apis).
+
+```javascript
+
+// before
+export default DS.RESTSerializer.extend({
+  isNewSerializerAPI: true
+});
+
+// after
+
+export default DS.RESTSerializer.extend({});
+```
 
 ### Specifying a file or path.
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -82,12 +82,21 @@ program
   });
 
 program
+  .command('remove-ember-data-is-new-serializer-api [path]')
+  .description('Remove `isNewSerializerAPI` in Ember Data serializers.')
+  .action(function(path) {
+    path = path || 'app/serializers';
+    watson.removeEmberDataIsNewSerializerAPI(path);
+  });
+
+program
   .command('all')
   .option('--tests-path [path]', 'Path to tests directory.', 'tests')
   .option('--app-path [path]', 'Path to app directory.', 'app')
   .option('--router-path [path]', 'Path to router file.', 'app/router.js')
   .option('--acceptance-path [path]', 'Path to acceptance tests directory.', 'tests/acceptance')
   .option('--controllers-path [path]', 'Path to controllers directory.', 'app/controllers')
+  .option('--serializers-path [path]', 'Path to serializers directory.', 'app/serializers')
   .option('--output [format]', 'Output format: pretty or json.', 'pretty')
   .description('Run all commands.')
   .action(function(options) {
@@ -100,6 +109,7 @@ program
     watson.findOverloadedCPs(options.appPath).outputSummary(options.output);
     watson.transformTestToUseDestroyApp(options.acceptancePath);
     watson.replaceNeedsWithInjection(options.controllersPath);
+    watson.removeEmberDataIsNewSerializerAPI(options.serializersPath);
   });
 
 module.exports = function init(args) {

--- a/lib/commands/remove-ember-data-is-new-serializer-api.js
+++ b/lib/commands/remove-ember-data-is-new-serializer-api.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var Watson = require('../../index');
+
+module.exports = {
+  name: 'watson:remove-ember-data-is-new-serializer-api',
+  description: 'Removes `isNewSerializerAPI` from serialiers',
+  works: ['insideProject', 'insideAddon'],
+  anonymousOptions: [
+    '<path>'
+  ],
+  run: function(commandOptions, rawArgs) {
+    var path = rawArgs[0] || 'app';
+  }
+};

--- a/lib/formulas/remove-ember-data-is-new-serializer-api.js
+++ b/lib/formulas/remove-ember-data-is-new-serializer-api.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var parseAST = require('../helpers/parse-ast');
+var recast = require('recast');
+
+module.exports = function(source) {
+  var ast = parseAST(source);
+
+  recast.visit(ast, {
+
+    visitCallExpression: function(path) {
+      var callee = path.node.callee;
+      if (callee.type === 'MemberExpression' &&
+          callee.property &&
+          callee.property.name === 'extend' &&
+          callee.object &&
+          callee.object.property &&
+          /serializer/i.test(callee.object.property.name)) {
+        this.traverse(path);
+        return;
+      }
+
+      return false;
+    },
+
+    visitProperty: function(path) {
+      if (path.node.key.name === 'isNewSerializerAPI') {
+        path.prune();
+      }
+      return false;
+    }
+  });
+
+  return recast.print(ast, { tabWidth: 2, quote: 'single' }).code;
+};

--- a/lib/helpers/find-files.js
+++ b/lib/helpers/find-files.js
@@ -1,12 +1,13 @@
 var path      = require('path');
 var walkSync  = require('walk-sync');
+var fs        = require('fs');
 
 module.exports = function(rootPath, ext) {
   var files = [];
 
   if (path.extname(rootPath).length > 0) {
     files.push(rootPath);
-  } else {
+  } else if (fs.existsSync(rootPath)) {
     files = walkSync(rootPath).filter(function(file) {
       return path.extname(file) === ext;
     }).map(function(file) {

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -14,10 +14,17 @@ var transformMethodify = require('./formulas/methodify');
 var FindOverloadedCPs = require('./formulas/find-overloaded-cps');
 var transformDestroyApp = require('./formulas/destroy-app-transform');
 var replaceNeedsWithInjection = require('./formulas/replace-needs-with-injection');
+var removeEmberDataIsNewSerializerAPI = require('./formulas/remove-ember-data-is-new-serializer-api');
 
 module.exports = EmberWatson;
 
 function EmberWatson() { }
+
+EmberWatson.prototype._removeEmberDataIsNewSerializerAPI = removeEmberDataIsNewSerializerAPI;
+EmberWatson.prototype.removeEmberDataIsNewSerializerAPI = function(path) {
+  var files = findFiles(path, '.js');
+  transform(files, this._removeEmberDataIsNewSerializerAPI);
+};
 
 EmberWatson.prototype._transformEmberDataAsyncFalseRelationships = transformEmberDataAsyncFalseRelationships;
 

--- a/tests/fixtures/remove-ember-data-is-new-serializer-api/new/serializer.js
+++ b/tests/fixtures/remove-ember-data-is-new-serializer-api/new/serializer.js
@@ -1,0 +1,3 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({});

--- a/tests/fixtures/remove-ember-data-is-new-serializer-api/old/serializer.js
+++ b/tests/fixtures/remove-ember-data-is-new-serializer-api/old/serializer.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  isNewSerializerAPI: true
+});

--- a/tests/remove-ember-data-is-new-serializer-api-test.js
+++ b/tests/remove-ember-data-is-new-serializer-api-test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var Watson      = require('../index.js');
+var fs          = require('fs');
+var astEquality = require('./helpers/ast-equality');
+var recast      = require('recast');
+
+
+describe('ember data isNewSerializerAPI', function(){
+  var baseDir = './tests/fixtures/remove-ember-data-is-new-serializer-api';
+  var watson;
+
+  beforeEach(function(){
+    watson = new Watson();
+  });
+
+  describe('removing isNewSerializerAPI literals', function() {
+
+    it('removes the isNewSerializerAPI directive', function() {
+      var source            = fs.readFileSync(baseDir + '/old/serializer.js');
+      var newSource         = watson._removeEmberDataIsNewSerializerAPI(source);
+      var expectedNewSource = fs.readFileSync(baseDir + '/new/serializer.js');
+
+      astEquality(newSource, expectedNewSource);
+    });
+  });
+});


### PR DESCRIPTION
This adds a handy command for removing all the `isNewSerializerAPI`
properties in serializers after you've finished upgrading.