### PR TITLE
Add --dry-run command to get the codeclimate-watson working

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,82 +11,92 @@ program
 program
   .command('upgrade-qunit-tests [testsPath]')
   .description('Fix QUnit tests to match 2.0 syntax. testsPath defaults to tests/')
-  .action(function(testsPath){
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(testsPath, options){
     testsPath = testsPath || 'tests';
-    watson.transformQUnitTest(testsPath);
+    watson.transformQUnitTest(testsPath, options.dryRun);
   });
 
 program
   .command('convert-prototype-extensions [appPath]')
   .description('Convert computed properties and observers to not use prototype extensions. appPath defaults to app/')
-  .action(function(appPath){
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(appPath, options){
     appPath = appPath || 'app';
-    watson.transformPrototypeExtensions(appPath);
+    watson.transformPrototypeExtensions(appPath, options.dryRun);
   });
 
 program
   .command('convert-ember-data-model-lookups [appPath]')
   .description('convert Ember Data model lookups to use a dasherized string')
-  .action(function(appPath) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(appPath, options) {
     appPath = appPath || 'app';
-    watson.transformEmberDataModelLookups(appPath);
+    watson.transformEmberDataModelLookups(appPath, options.dryRun);
   });
 
 program
   .command('convert-ember-data-async-false-relationships [appPath]')
   .description('convert Ember Data relationship with implicit async: false to explicit option')
-  .action(function(appPath) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(appPath, options) {
     appPath = appPath || 'app';
-    watson.transformEmberDataAsyncFalseRelationships(appPath);
+    watson.transformEmberDataAsyncFalseRelationships(appPath, options.dryRun);
   });
 
 program
   .command('convert-resource-router-mapping [routerPath]')
   .description('convert the resource router mapping to use the route mapping with the new resetNamespace option')
-  .action(function(routerPath) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(routerPath, options) {
     routerPath = routerPath || 'app/router.js';
-    watson.transformResourceRouterMapping(routerPath);
+    watson.transformResourceRouterMapping(routerPath, options.dryRun);
   });
 
 program
   .command('methodify [path]')
   .description('Convert methods to new ES6 syntax')
-  .action(function(path) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(path, options) {
     path = path || 'app';
-    watson.transformMethodify(path);
+    watson.transformMethodify(path, options.dryRun);
   });
 
 program
   .command('find-overloaded-cps [path]')
   .option('-j, --json', 'Output in JSON instead of pretty print.')
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
   .description('This lists all the places that will trigger the "Using the same function as getter and setter" deprecation.')
   .action(function(path, options) {
     path = path || 'app';
-    watson.findOverloadedCPs(path).outputSummary(options.json ? 'json' : 'pretty');
+    watson.findOverloadedCPs(path, options.dryRun).outputSummary(options.json ? 'json' : 'pretty');
   });
 
 program
   .command('use-destroy-app-helper [path]')
   .description('Use destroy-app helper after acceptance tests.')
-  .action(function(path) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(path, options) {
     path = path || 'tests/acceptance';
-    watson.transformTestToUseDestroyApp(path);
+    watson.transformTestToUseDestroyApp(path, options.dryRun);
   });
 
 program
   .command('replace-needs-with-injection [path]')
   .description('Replace needs with controller injection.')
-  .action(function(path) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(path, options) {
     path = path || 'app/controllers';
-    watson.replaceNeedsWithInjection(path);
+    watson.replaceNeedsWithInjection(path, options.dryRun);
   });
 
 program
   .command('remove-ember-data-is-new-serializer-api [path]')
   .description('Remove `isNewSerializerAPI` in Ember Data serializers.')
-  .action(function(path) {
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
+  .action(function(path, options) {
     path = path || 'app/serializers';
-    watson.removeEmberDataIsNewSerializerAPI(path);
+    watson.removeEmberDataIsNewSerializerAPI(path, options.dryRun);
   });
 
 program
@@ -98,18 +108,19 @@ program
   .option('--controllers-path [path]', 'Path to controllers directory.', 'app/controllers')
   .option('--serializers-path [path]', 'Path to serializers directory.', 'app/serializers')
   .option('--output [format]', 'Output format: pretty or json.', 'pretty')
+  .option('--dry-run', 'Don\'t modify files, output JSON instead')
   .description('Run all commands.')
   .action(function(options) {
-    watson.transformQUnitTest(options.testsPath);
-    watson.transformPrototypeExtensions(options.appPath);
-    watson.transformEmberDataModelLookups(options.appPath);
-    watson.transformEmberDataAsyncFalseRelationships(options.appPath);
-    watson.transformResourceRouterMapping(options.routerPath);
-    watson.transformMethodify(options.appPath);
-    watson.findOverloadedCPs(options.appPath).outputSummary(options.output);
-    watson.transformTestToUseDestroyApp(options.acceptancePath);
-    watson.replaceNeedsWithInjection(options.controllersPath);
-    watson.removeEmberDataIsNewSerializerAPI(options.serializersPath);
+    watson.transformQUnitTest(options.testsPath, options.dryRun);
+    watson.transformPrototypeExtensions(options.appPath, options.dryRun);
+    watson.transformEmberDataModelLookups(options.appPath, options.dryRun);
+    watson.transformEmberDataAsyncFalseRelationships(options.appPath, options.dryRun);
+    watson.transformResourceRouterMapping(options.routerPath, options.dryRun);
+    watson.transformMethodify(options.appPath, options.dryRun);
+    watson.findOverloadedCPs(options.appPath, options.dryRun).outputSummary(options.output);
+    watson.transformTestToUseDestroyApp(options.acceptancePath, options.dryRun);
+    watson.replaceNeedsWithInjection(options.controllersPath, options.dryRun);
+    watson.removeEmberDataIsNewSerializerAPI(options.serializersPath, options.dryRun);
   });
 
 module.exports = function init(args) {

--- a/lib/commands/all.js
+++ b/lib/commands/all.js
@@ -14,16 +14,18 @@ module.exports = {
     { name: 'output', type: String, description: 'Output format: pretty or json.', default: 'pretty' },
     { name: 'acceptance-path', type: String, description: 'Path to acceptance tests directory.', default: 'tests/acceptance' },
     { name: 'controllers-path', type: String, description: 'Path to controllers directory.', default: 'app/controllers' },
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
   ],
   run: function(options) {
-    watson.transformQUnitTest(options.testsPath);
-    watson.transformPrototypeExtensions(options.appPath);
-    watson.transformEmberDataModelLookups(options.appPath);
-    watson.transformEmberDataAsyncFalseRelationships(options.appPath);
-    watson.transformResourceRouterMapping(options.routerPath);
-    watson.transformMethodify(options.appPath);
-    watson.findOverloadedCPs(options.appPath).outputSummary(options.output);
-    watson.transformTestToUseDestroyApp(options.acceptancePath);
-    watson.replaceNeedsWithInjection(options.controllersPath);
+    watson.transformQUnitTest(options.testsPath, options.dryRun);
+    watson.transformPrototypeExtensions(options.appPath, options.dryRun);
+    watson.transformEmberDataModelLookups(options.appPath, options.dryRun);
+    watson.transformEmberDataAsyncFalseRelationships(options.appPath, options.dryRun);
+    watson.transformResourceRouterMapping(options.routerPath, options.dryRun);
+    watson.transformMethodify(options.appPath, options.dryRun);
+    watson.findOverloadedCPs(options.appPath, options.dryRun).outputSummary(options.output);
+    watson.transformTestToUseDestroyApp(options.acceptancePath, options.dryRun);
+    watson.replaceNeedsWithInjection(options.controllersPath, options.dryRun);
+    watson.removeEmberDataIsNewSerializerAPI(options.appPath, options.dryRun);
   }
 };

--- a/lib/commands/convert-ember-data-async-false-relationships.js
+++ b/lib/commands/convert-ember-data-async-false-relationships.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'app';
-    watson.transformEmberDataAsyncFalseRelationships(path);
+    watson.transformEmberDataAsyncFalseRelationships(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/convert-ember-data-model-lookups.js
+++ b/lib/commands/convert-ember-data-model-lookups.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'app';
-    watson.transformEmberDataModelLookups(path);
+    watson.transformEmberDataModelLookups(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/convert-prototype-extensions.js
+++ b/lib/commands/convert-prototype-extensions.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'app';
-    watson.transformPrototypeExtensions(path);
+    watson.transformPrototypeExtensions(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/convert-resource-router-mapping.js
+++ b/lib/commands/convert-resource-router-mapping.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<routerPath>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'app/router.js';
-    watson.transformResourceRouterMapping(path);
+    watson.transformResourceRouterMapping(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/find-overloaded-cps.js
+++ b/lib/commands/find-overloaded-cps.js
@@ -10,9 +10,12 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'app';
     var reportFormat = commandOptions.json ? 'json' : 'pretty';
-    watson.findOverloadedCPs(path).outputSummary(reportFormat);
+    watson.findOverloadedCPs(path, commandOptions.dryRun).outputSummary(reportFormat);
   }
 };

--- a/lib/commands/methodify.js
+++ b/lib/commands/methodify.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] || 'app';
-    watson.transformMethodify(path);
+    watson.transformMethodify(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/remove-ember-data-is-new-serializer-api.js
+++ b/lib/commands/remove-ember-data-is-new-serializer-api.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Watson = require('../../index');
+var watson = new Watson();
 
 module.exports = {
   name: 'watson:remove-ember-data-is-new-serializer-api',
@@ -9,7 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] || 'app';
+    watson.removeEmberDataIsNewSerializerAPI(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/replace-needs-with-injection.js
+++ b/lib/commands/replace-needs-with-injection.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] || 'app/controllers';
-    watson.replaceNeedsWithInjection(path);
+    watson.replaceNeedsWithInjection(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/upgrade-qunit-tests.js
+++ b/lib/commands/upgrade-qunit-tests.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] ||  'tests';
-    watson.transformQUnitTest(path);
+    watson.transformQUnitTest(path, commandOptions.dryRun);
   }
 };

--- a/lib/commands/use-destroy-app-helper.js
+++ b/lib/commands/use-destroy-app-helper.js
@@ -10,8 +10,11 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'dry-run', type: Boolean, description: 'Run the command in dry-run mode (outputs JSON, non-destructive)', default: false }
+  ],
   run: function(commandOptions, rawArgs) {
     var path = rawArgs[0] || 'tests/acceptance';
-    watson.transformTestToUseDestroyApp(path);
+    watson.transformTestToUseDestroyApp(path, commandOptions.dryRun);
   }
 };

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -21,69 +21,69 @@ module.exports = EmberWatson;
 function EmberWatson() { }
 
 EmberWatson.prototype._removeEmberDataIsNewSerializerAPI = removeEmberDataIsNewSerializerAPI;
-EmberWatson.prototype.removeEmberDataIsNewSerializerAPI = function(path) {
+EmberWatson.prototype.removeEmberDataIsNewSerializerAPI = function(path, dryRun) {
   var files = findFiles(path, '.js');
-  transform(files, this._removeEmberDataIsNewSerializerAPI);
+  transform(files, this._removeEmberDataIsNewSerializerAPI, dryRun);
 };
 
 EmberWatson.prototype._transformEmberDataAsyncFalseRelationships = transformEmberDataAsyncFalseRelationships;
 
-EmberWatson.prototype.transformEmberDataAsyncFalseRelationships = function(rootPath) {
+EmberWatson.prototype.transformEmberDataAsyncFalseRelationships = function(rootPath, dryRun) {
   var files = findFiles(rootPath, '.js');
 
-  transform(files, this._transformEmberDataAsyncFalseRelationships);
+  transform(files, this._transformEmberDataAsyncFalseRelationships, dryRun);
 };
 
 EmberWatson.prototype._transformEmberDataModelLookups = transformEmberDataModelLookups;
 
-EmberWatson.prototype.transformEmberDataModelLookups = function(rootPath) {
+EmberWatson.prototype.transformEmberDataModelLookups = function(rootPath, dryRun) {
   var files = findFiles(rootPath, '.js');
 
-  transform(files, this._transformEmberDataModelLookups);
+  transform(files, this._transformEmberDataModelLookups, dryRun);
 };
 
 EmberWatson.prototype._transformQUnitTest = qunitTransforms;
 
-EmberWatson.prototype.transformQUnitTest = function(rootPath) {
+EmberWatson.prototype.transformQUnitTest = function(rootPath, dryRun) {
   var tests  = findFiles(rootPath, '.js').filter(function(file){
     return file.indexOf('-test.js') > 0;
   });
 
-  transform(tests, this._transformQUnitTest);
+  transform(tests, this._transformQUnitTest, dryRun);
 };
 
 EmberWatson.prototype._transformPrototypeExtensions = prototypeExtensionTransforms;
 
-EmberWatson.prototype.transformPrototypeExtensions = function(rootPath) {
+EmberWatson.prototype.transformPrototypeExtensions = function(rootPath, dryRun) {
   var files = findFiles(rootPath, '.js');
 
-  transform(files, this._transformPrototypeExtensions);
+  transform(files, this._transformPrototypeExtensions, dryRun);
 };
 
 EmberWatson.prototype._transformMethodify = transformMethodify;
-EmberWatson.prototype.transformMethodify = function(rootPath) {
+EmberWatson.prototype.transformMethodify = function(rootPath, dryRun) {
   var files = findFiles(rootPath, '.js');
 
-  transform(files, this._transformMethodify);
+  transform(files, this._transformMethodify, dryRun);
 };
 
 EmberWatson.prototype._transformResourceRouterMapping = transformResourceRouterMapping;
 
-EmberWatson.prototype.transformResourceRouterMapping = function(routerPath) {
-  transform([routerPath], this._transformResourceRouterMapping);
+EmberWatson.prototype.transformResourceRouterMapping = function(routerPath, dryRun) {
+  transform([routerPath], this._transformResourceRouterMapping, dryRun);
 };
 
 EmberWatson.prototype._transformDestroyApp = transformDestroyApp;
 
-EmberWatson.prototype.replaceNeedsWithInjection = function(path) {
+EmberWatson.prototype.replaceNeedsWithInjection = function(path, dryRun) {
   var files = findFiles(path, '.js');
-  transform(files, this._replaceNeedsWithInjection);
+  transform(files, this._replaceNeedsWithInjection, dryRun);
 };
 
 EmberWatson.prototype._replaceNeedsWithInjection = replaceNeedsWithInjection;
 
-EmberWatson.prototype.transformTestToUseDestroyApp = function(rootPath) {
-  if (!existsSync('tests/helpers/destroy-app.js')) {
+EmberWatson.prototype.transformTestToUseDestroyApp = function(rootPath, dryRun) {
+  if (!existsSync('tests/helpers/destroy-app.js') && !dryRun) {
     console.log(
       chalk.red('tests/helpers/destroy-app.js file is not present. ' +
         'You must either manually place the file or upgrade to an ' +
@@ -99,19 +99,19 @@ EmberWatson.prototype.transformTestToUseDestroyApp = function(rootPath) {
     return file.indexOf('-test.js') > 0;
   });
 
-  transform(tests, this._transformDestroyApp);
+  transform(tests, this._transformDestroyApp, dryRun);
 };
 
-EmberWatson.prototype.findOverloadedCPs = function(rootPath) {
+EmberWatson.prototype.findOverloadedCPs = function(rootPath, dryRun) {
   var searcher = new FindOverloadedCPs();
   transform(findFiles(rootPath, '.js'), function(source, filename) {
     searcher.examineSource(source, filename);
     return source;
-  });
+  }, dryRun);
   return searcher;
-};
-
-function transform(files, transformFormula) {
+}
+;
+function transform(files, transformFormula, dryRun) {
   var wontFix = [];
 
   files.forEach(function(file) {
@@ -119,9 +119,13 @@ function transform(files, transformFormula) {
     try {
       var newSource = transformFormula(source, file);
       if (source != newSource) {
-        console.log(chalk.green('Fixed: ', file));
+        if (dryRun) {
+          console.log({ path: file, formula: formulaName.name }, '\0');
+        } else {
+          console.log(chalk.green('Fixed: ', file));
 
-        fs.writeFileSync(file, newSource);
+          fs.writeFileSync(file, newSource);
+        }
       }
     } catch (error) {
       wontFix.push({
@@ -131,7 +135,7 @@ function transform(files, transformFormula) {
     }
   }, this);
 
-  if (wontFix.length > 0) {
+  if (wontFix.length > 0 && !dryRun) {
     console.log(
       chalk.red('\n\nOh Dear! I wasn\'t able to save the following files:')
     );

--- a/tests/commands-test.js
+++ b/tests/commands-test.js
@@ -85,40 +85,52 @@ describe('Commands:', function () {
     var Command = require('../lib/commands/convert-ember-data-model-lookups');
 
     Command.run({}, []);
-    assert.deepEqual(transformEmberDataModelLookupsCalledWith, ['app']);
+    assert.deepEqual(transformEmberDataModelLookupsCalledWith, ['app', undefined]);
 
     Command.run({}, ['some-app']);
-    assert.deepEqual(transformEmberDataModelLookupsCalledWith, ['some-app']);
+    assert.deepEqual(transformEmberDataModelLookupsCalledWith, ['some-app', undefined]);
+
+    Command.run({ dryRun: true }, ['some-app']);
+    assert.deepEqual(transformEmberDataModelLookupsCalledWith, ['some-app', true]);
   });
 
   it('convert-ember-data-async-false-relationships calls the correct transform', function () {
     var Command = require('../lib/commands/convert-ember-data-async-false-relationships');
 
     Command.run({}, []);
-    assert.deepEqual(transformEmberDataAsyncFalseRelationshipsCalledWith, ['app']);
+    assert.deepEqual(transformEmberDataAsyncFalseRelationshipsCalledWith, ['app', undefined]);
 
     Command.run({}, ['some-app']);
-    assert.deepEqual(transformEmberDataAsyncFalseRelationshipsCalledWith, ['some-app']);
+    assert.deepEqual(transformEmberDataAsyncFalseRelationshipsCalledWith, ['some-app', undefined]);
+
+    Command.run({ dryRun: true }, ['some-app']);
+    assert.deepEqual(transformEmberDataAsyncFalseRelationshipsCalledWith, ['some-app', true]);
   });
 
   it('convert-prototype-extensions calls the correct transform', function () {
     var Command = require('../lib/commands/convert-prototype-extensions');
 
     Command.run({}, []);
-    assert.deepEqual(transformPrototypeExtensionsCalledWith, ['app']);
+    assert.deepEqual(transformPrototypeExtensionsCalledWith, ['app', undefined]);
 
     Command.run({}, ['some-app']);
-    assert.deepEqual(transformPrototypeExtensionsCalledWith, ['some-app']);
+    assert.deepEqual(transformPrototypeExtensionsCalledWith, ['some-app', undefined]);
+
+    Command.run({ dryRun: true }, ['some-app']);
+    assert.deepEqual(transformPrototypeExtensionsCalledWith, ['some-app', true]);
   });
 
   it('upgrade-qunit-tests calls the correct transform', function () {
     var Command = require('../lib/commands/upgrade-qunit-tests');
 
     Command.run({}, []);
-    assert.deepEqual(transformQUnitTestCalledWith , ['tests']);
+    assert.deepEqual(transformQUnitTestCalledWith , ['tests', undefined]);
 
     Command.run({}, ['other-dir']);
-    assert.deepEqual(transformQUnitTestCalledWith , ['other-dir']);
+    assert.deepEqual(transformQUnitTestCalledWith , ['other-dir', undefined]);
+
+    Command.run({ dryRun: true }, ['other-dir']);
+    assert.deepEqual(transformQUnitTestCalledWith , ['other-dir', true]);
   });
 
   it('convert-resource-router-mapping calls the correct transform', function() {
@@ -127,13 +139,19 @@ describe('Commands:', function () {
     Command.run({}, []);
     assert.deepEqual(
       transformResourceRouterMappingCalledWith,
-      ['app/router.js']
+      ['app/router.js', undefined]
     );
 
     Command.run({}, ['other-router']);
     assert.deepEqual(
       transformResourceRouterMappingCalledWith,
-      ['other-router']
+      ['other-router', undefined]
+    );
+
+    Command.run({ dryRun: true }, ['other-router']);
+    assert.deepEqual(
+      transformResourceRouterMappingCalledWith,
+      ['other-router', true]
     );
   });
 
@@ -141,19 +159,25 @@ describe('Commands:', function () {
     var Command = require('../lib/commands/methodify');
 
     Command.run({}, []);
-    assert.deepEqual(transformMethodifyCalledWith, ['app']);
+    assert.deepEqual(transformMethodifyCalledWith, ['app', undefined]);
 
     Command.run({}, ['some-app']);
-    assert.deepEqual(transformMethodifyCalledWith, ['some-app']);
+    assert.deepEqual(transformMethodifyCalledWith, ['some-app', undefined]);
+
+    Command.run({ dryRun: true }, ['some-app']);
+    assert.deepEqual(transformMethodifyCalledWith, ['some-app', true]);
   });
 
   it('methodify calls the correct transform', function () {
     var Command = require('../lib/commands/use-destroy-app-helper');
 
     Command.run({}, []);
-    assert.deepEqual(transformTestToUseDestroyAppCalledWith, ['tests/acceptance']);
+    assert.deepEqual(transformTestToUseDestroyAppCalledWith, ['tests/acceptance', undefined]);
 
     Command.run({}, ['tests/my-crazy-other-thing']);
-    assert.deepEqual(transformTestToUseDestroyAppCalledWith, ['tests/my-crazy-other-thing']);
+    assert.deepEqual(transformTestToUseDestroyAppCalledWith, ['tests/my-crazy-other-thing', undefined]);
+
+    Command.run({ dryRun: true }, ['tests/my-crazy-other-thing']);
+    assert.deepEqual(transformTestToUseDestroyAppCalledWith, ['tests/my-crazy-other-thing', true]);
   });
 });


### PR DESCRIPTION
I discussed this with @mrb earlier in the week. This PR adds a `--dry-run` option which outputs JSON that can be used by CodeClimate to analyze commits.

I'd love to get this in so we can start using the `watson` engine on CodeClimate again!