### PR TITLE
Wrap ember-k-codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Convert `needs` declarations the individual properties using
 the new `Ember.inject.controller()` feature. Also convert any uses
 of the `controllers` hash to use the newly defined properties.
 
+### Remove usages of Ember.K
+
+```sh
+ember watson:remove-ember-k <mode>
+```
+
+Replaces all usages of `Ember.K` with just plain functions.
+The `<mode>` argument is mandatory and can be `--empty` or `--return-this`.
+Invoked with `--empty` it will replace `Ember.K` with an empty function, which is more idiomatic JS.
+Invoked with `--return-empty` it will replace it by a function that returns `this` so allows chaining.
+This command runs automatically in all folders that might contain ember code, so no `<path>` or `--dry-run`
+options are available.
 
 ### Tests: Upgrade QUnit Tests
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -85,8 +85,12 @@ program
 program
   .command('remove-ember-k')
   .description('Removes all usages of Ember.K.')
-  .action(function() {
-    watson.removeEmberK();
+  .option('--empty', 'Replaces usages `Ember.K` with an empty function')
+  .option('--return-this', 'Replaces usages `Ember.K` with a function that returns `this` to allow chaining')
+  .action(function(opts) {
+    var replacementArg = opts.parent.args[0];
+    var strategy = replacementArg.empty ? 'empty' : (replacementArg.returnThis ? 'return-this' : null);
+    watson.removeEmberK(strategy);
   });
 
 program

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -81,6 +81,14 @@ program
     watson.transformTestToUseDestroyApp(path, options.dryRun);
   });
 
+
+program
+  .command('remove-ember-k')
+  .description('Removes all usages of Ember.K.')
+  .action(function() {
+    watson.removeEmberK();
+  });
+
 program
   .command('replace-needs-with-injection [path]')
   .description('Replace needs with controller injection.')

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -10,6 +10,7 @@ module.exports = {
   'watson:convert-resource-router-mapping': require('./convert-resource-router-mapping'),
   'watson:find-overloaded-cps': require('./find-overloaded-cps'),
   'watson:use-destroy-app-helper': require('./use-destroy-app-helper'),
+  'watson:remove-ember-k': require('./remove-ember-k'),
   'watson:replace-needs-with-injection': require('./replace-needs-with-injection'),
   'watson:remove-ember-data-is-new-serializer-api': require('./remove-ember-data-is-new-serializer-api')
 };

--- a/lib/commands/remove-ember-k.js
+++ b/lib/commands/remove-ember-k.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var Watson = require('../../index');
+var watson = new Watson();
+
+module.exports = {
+  name: 'watson:remove-ember-k',
+  description: 'Removes all usages of Ember.K',
+  works: 'insideProject',
+  anonymousOptions: [
+    '<path>'
+  ],
+  run: function() {
+    watson.removeEmberK();
+  }
+};

--- a/lib/commands/remove-ember-k.js
+++ b/lib/commands/remove-ember-k.js
@@ -10,6 +10,10 @@ module.exports = {
   anonymousOptions: [
     '<path>'
   ],
+  availableOptions: [
+    { name: 'empty', type: Boolean, description: 'Replaces usages `Ember.K` with an empty function', default: false },
+    { name: 'return-this', type: Boolean, description: 'Replaces usages `Ember.K` with a function that returns `this` to allow chaining', default: false }
+  ],
   run: function() {
     watson.removeEmberK();
   }

--- a/lib/formulas/remove-ember-k.js
+++ b/lib/formulas/remove-ember-k.js
@@ -3,9 +3,13 @@
 var spawn = require('child_process').spawn;
 var path = require("path");
 
-module.exports = function removeEmberK() {
+module.exports = function removeEmberK(strategy) {
   var binPath = path.dirname(require.resolve("ember-k-codemod")) + "/bin/ember-k-codemod.js";
-  spawn(binPath, [], {
+  var args = [];
+  if (strategy) {
+    args.push('--' + strategy);
+  }
+  spawn(binPath, args, {
     stdio: "inherit",
     env: process.env
   });

--- a/lib/formulas/remove-ember-k.js
+++ b/lib/formulas/remove-ember-k.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var spawn = require('child_process').spawn;
+var path = require("path");
+
+module.exports = function removeEmberK() {
+  var binPath = path.dirname(require.resolve("ember-k-codemod")) + "/bin/ember-k-codemod.js";
+  spawn(binPath, [], {
+    stdio: "inherit",
+    env: process.env
+  });
+};

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -13,6 +13,7 @@ var transformResourceRouterMapping = require('./formulas/resource-router-mapping
 var transformMethodify = require('./formulas/methodify');
 var FindOverloadedCPs = require('./formulas/find-overloaded-cps');
 var transformDestroyApp = require('./formulas/destroy-app-transform');
+var removeEmberK = require('./formulas/remove-ember-k');
 var replaceNeedsWithInjection = require('./formulas/replace-needs-with-injection');
 var removeEmberDataIsNewSerializerAPI = require('./formulas/remove-ember-data-is-new-serializer-api');
 
@@ -74,6 +75,8 @@ EmberWatson.prototype.transformResourceRouterMapping = function(routerPath, dryR
 };
 
 EmberWatson.prototype._transformDestroyApp = transformDestroyApp;
+
+EmberWatson.prototype.removeEmberK = removeEmberK;
 
 EmberWatson.prototype.replaceNeedsWithInjection = function(path, dryRun) {
   var files = findFiles(path, '.js');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "exists-sync": "0.0.3",
     "inflected": "^1.1.6",
     "recast": "^0.10.29",
-    "walk-sync": "^0.1.3"
+    "walk-sync": "^0.1.3",
+    "ember-k-codemod": "^0.0.4"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "inflected": "^1.1.6",
     "recast": "^0.10.29",
     "walk-sync": "^0.1.3",
-    "ember-k-codemod": "^0.0.5"
+    "ember-k-codemod": "^0.1.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "inflected": "^1.1.6",
     "recast": "^0.10.29",
     "walk-sync": "^0.1.3",
-    "ember-k-codemod": "^0.0.4"
+    "ember-k-codemod": "^0.0.5"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
I've created https://github.com/cibernox/ember-k-codemod for complement a (likely) future deprecation in ember (https://github.com/cibernox/rfcs/blob/deprecate-ember-k/text/0000-deprecate-ember-k.md) but it's probably more idiomatic to distribute it in ember-watson because a lot of people knows and trust the tool.

This naive approach just adds a tasks that in turn runs the binary. There is no tests because `ember-k-codemod` is tested and its an utility that takes no options.

Let me know if I should change anything on the approach.